### PR TITLE
Handle playback errors in PlayTrack and surface failures

### DIFF
--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -299,18 +299,25 @@ public partial class MainWindowViewModel : ViewModelBase, IDisposable
     {
         if (track == null) return;
 
-        CurrentTrack = track;
-        _audioPlayer.Play(track);
-
-        if (ShuffleEnabled)
+        try
         {
-            var index = Tracks.IndexOf(track);
-            if (_shuffleHistoryIndex < _shuffleHistory.Count - 1)
+            _audioPlayer.Play(track);
+            CurrentTrack = track;
+
+            if (ShuffleEnabled)
             {
-                _shuffleHistory.RemoveRange(_shuffleHistoryIndex + 1, _shuffleHistory.Count - _shuffleHistoryIndex - 1);
+                var index = Tracks.IndexOf(track);
+                if (_shuffleHistoryIndex < _shuffleHistory.Count - 1)
+                {
+                    _shuffleHistory.RemoveRange(_shuffleHistoryIndex + 1, _shuffleHistory.Count - _shuffleHistoryIndex - 1);
+                }
+                _shuffleHistory.Add(index);
+                _shuffleHistoryIndex = _shuffleHistory.Count - 1;
             }
-            _shuffleHistory.Add(index);
-            _shuffleHistoryIndex = _shuffleHistory.Count - 1;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Unable to play '{track.DisplayName}': {ex.Message}";
         }
     }
 


### PR DESCRIPTION
### Motivation
- Playback could cause the app to crash or be suspended (especially on Windows when native audio fails), so playback should be guarded to avoid crashing the UI.
- `CurrentTrack` and shuffle history must only be updated when playback actually starts successfully.

### Description
- Wrap the `PlayTrack(Track?)` implementation in a `try/catch` and invoke `_audioPlayer.Play(track)` inside the guarded block.
- Move assignment of `CurrentTrack` and the shuffle-history updates to occur only after successful playback, and set `StatusMessage` on exception using `StatusMessage = $"Unable to play '{track.DisplayName}': {ex.Message}"`.
- This change prevents unhandled exceptions from propagating during playback start and ensures internal state is consistent when playback fails.

### Testing
- No automated tests were run for this change.
- The change was committed and compiled locally as part of the edit cycle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f686077608332a98f16f4442f72c5)